### PR TITLE
fixes#1 - 게임 시작 이후 방장이 채팅할 수 없는 버그 픽스

### DIFF
--- a/src/main/java/game/GameContext.java
+++ b/src/main/java/game/GameContext.java
@@ -30,11 +30,11 @@ public class GameContext {
 	void gameStart() {
 		this.isPlaying = true; //게임중으로 표시
 		PhaseTimer phaseTimer = new PhaseTimer(); // Phase를 진행시키는 타이머 초기화
-		phaseTimer.setPhase(NightPhase.getInstance()); // 초기 Phase는 NightPhase로 설정
 		phaseTimer.setGameContext(this);
+		phaseTimer.setPhase(NightPhase.getInstance()); // 초기 Phase는 NightPhase로 설정
 		this.initAllocableJobList();
 		this.allocJob();
-		phaseTimer.run();
+		phaseTimer.start();
 	}
 
 	boolean isPlaying() {
@@ -92,6 +92,10 @@ public class GameContext {
 			user.sendProtocol(protocol);
 			System.out.println(user.getUserId() + " : " + user.getJob().getClass().getSimpleName());
 		}
+	}
+
+	public GameRoom getGameRoom() {
+		return this.gameRoom;
 	}
 	
 }

--- a/src/main/java/game/GameRoom.java
+++ b/src/main/java/game/GameRoom.java
@@ -1,14 +1,10 @@
 package game;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
 import game.user.User;
 import protocol.Protocol;
 import protocol.system.subprotocol.RoomMasterSubSystemProtocol;
+
+import java.util.*;
 
 public class GameRoom {
 	// TODO : 현재는 싱글톤으로 되어있어 서버 하나에 게임방이 1개이지만, 이후 여러 개의 방을 생성할 수 있도록 변경

--- a/src/main/java/game/PhaseTimer.java
+++ b/src/main/java/game/PhaseTimer.java
@@ -1,6 +1,9 @@
 package game;
 
 import game.phase.Phase;
+import protocol.Protocol;
+import protocol.game.subprotocol.PhaseSubGameProtocol;
+import protocol.system.subprotocol.EndgameSubSystemProtocol;
 
 public class PhaseTimer extends Thread {
     private Phase phase;
@@ -26,17 +29,28 @@ public class PhaseTimer extends Thread {
         // 다음 Phase는 executeResult가 수행되는 도중 내부적으로 결정됨 (State Pattern)
         // GameContext.isPlaying 역시 executeResult가 수행되는 도중 내부적으로 결정됨
         if (gameContext.isPlaying()) {
-            this.run();
+            PhaseTimer phaseTimer = new PhaseTimer();
+            phaseTimer.setGameContext(this.gameContext);
+            phaseTimer.setPhase(this.phase);
+            phaseTimer.start();
         }
 
         // 게임이 끝난 경우
         else {
+            Protocol protocol = new EndgameSubSystemProtocol();
+            this.gameContext.getGameRoom().sendProtocol(protocol);
             System.out.println("게임 종료");
         }
     }
 
     public void setPhase(Phase phase) {
         this.phase = phase;
+
+        Protocol protocol = new PhaseSubGameProtocol()
+                                .setPhaseName(this.phase.getClass().getSimpleName());
+        System.out.println(this.phase.getClass().getSimpleName());
+        this.gameContext.getGameRoom().sendProtocol(protocol);
+
         this.remainPhaseTime = phase.getInterval();
     }
 

--- a/src/main/java/game/user/User.java
+++ b/src/main/java/game/user/User.java
@@ -1,12 +1,11 @@
 package game.user;
 
+import game.GameRoom;
 import game.job.Job;
 import message.MessageSenderReceiver;
 import protocol.Protocol;
 
 import java.net.Socket;
-
-import game.GameRoom;
 
 public class User extends Thread {
     private String userId; 	// 유저  id
@@ -44,6 +43,7 @@ public class User extends Thread {
         this.job = job;
         return this;
     }
+
 	@Override
     public void run() {
         while (!Thread.currentThread().isInterrupted()) {

--- a/src/main/java/message/MessageSenderReceiver.java
+++ b/src/main/java/message/MessageSenderReceiver.java
@@ -6,7 +6,10 @@ import protocol.Protocol;
 import protocol.system.subprotocol.LogoutSubSystemProtocol;
 import server.ServerFrame;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.net.Socket;
 
 public class MessageSenderReceiver {
@@ -36,6 +39,7 @@ public class MessageSenderReceiver {
             bodyMessageString = in.readLine();
             ServerFrame.getInstance().getTextArea().append(bodyMessageString);
         } catch (IOException e) {
+            e.printStackTrace();
             close();
         }
 

--- a/src/main/java/network/UserConnector.java
+++ b/src/main/java/network/UserConnector.java
@@ -1,12 +1,12 @@
 package network;
 
+import game.user.User;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 
-import game.user.User;
-
-public class UserConnector implements Runnable {
+public class UserConnector {
     // 서버 접속 포트
     private final static int PORT = 30000;
     private ServerSocket serverSocket;

--- a/src/main/java/protocol/chat/ChatProtocol.java
+++ b/src/main/java/protocol/chat/ChatProtocol.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import protocol.Protocol;
 import protocol.ProtocolType;
-import protocol.chat.subprotocol.*;
+import protocol.chat.subprotocol.DeadSubChatProtocol;
+import protocol.chat.subprotocol.MafiaSubChatProtocol;
+import protocol.chat.subprotocol.NormalSubChatProtocol;
+import protocol.chat.subprotocol.SystemSubChatProtocol;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/src/main/java/protocol/game/GameProtocol.java
+++ b/src/main/java/protocol/game/GameProtocol.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import protocol.Protocol;
 import protocol.ProtocolType;
-import protocol.game.subprotocol.*;
+import protocol.game.subprotocol.JobAllocationSubGameProtocol;
+import protocol.game.subprotocol.JobSubGameProtocol;
+import protocol.game.subprotocol.PhaseSubGameProtocol;
+import protocol.game.subprotocol.ResultSubGameProtocol;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/src/main/java/protocol/game/subprotocol/PhaseSubGameProtocol.java
+++ b/src/main/java/protocol/game/subprotocol/PhaseSubGameProtocol.java
@@ -8,6 +8,17 @@ import protocol.game.GameProtocol;
  * 클라 to 서버 : -
  **/
 public class PhaseSubGameProtocol extends GameProtocol {
+    private String phaseName;
+
+    public PhaseSubGameProtocol setPhaseName(String phaseName) {
+        this.phaseName = phaseName;
+        return this;
+    }
+
+    public String getPhaseName() {
+        return this.phaseName;
+    }
+
     @Override
     public void execute(User user) {
         System.out.println(this.getClass().getSimpleName() + ".execute()");

--- a/src/main/java/protocol/system/subprotocol/LoginSubSystemProtocol.java
+++ b/src/main/java/protocol/system/subprotocol/LoginSubSystemProtocol.java
@@ -1,10 +1,10 @@
 package protocol.system.subprotocol;
 
-import java.util.List;
-
 import game.GameRoom;
 import game.user.User;
 import protocol.system.SystemProtocol;
+
+import java.util.List;
 /**
  * 서버 to 클라 : 다른 유저가 로그인 한 정보를 알림
  * 클라 to 서버 : 해당 유저가 로그인을 요청


### PR DESCRIPTION
원인
1. PhaseTimer 쓰레드를 .start() 메서드로 실행시키지 않고 .run() 메서드로 실행
2. run() 메서드 내부에 while(true)로 돌고 있기 때문에 메시지가 전달되어도 처리되지 않고 버퍼에만 쌓임
3. run()내부의 while() 문이 끝나면 버퍼에 쌓인 메시지가 일괄출력
4. 방장만 채팅이 되지 않는 이유는 미상