### PR TITLE
fixes#3 - 첫 Phase 종료 후 다음 Phase가 2번 실행되는 문제 수정

### DIFF
--- a/src/main/java/game/GameContext.java
+++ b/src/main/java/game/GameContext.java
@@ -24,6 +24,10 @@ public class GameContext {
 		this.gameRoom = gameRoom;
 	}
 
+	public GameRoom getGameRoom() {
+		return this.gameRoom;
+	}
+
 	/**
 	 * 게임 시작
 	 **/
@@ -92,10 +96,6 @@ public class GameContext {
 			user.sendProtocol(protocol);
 			System.out.println(user.getUserId() + " : " + user.getJob().getClass().getSimpleName());
 		}
-	}
-
-	public GameRoom getGameRoom() {
-		return this.gameRoom;
 	}
 	
 }

--- a/src/main/java/game/PhaseTimer.java
+++ b/src/main/java/game/PhaseTimer.java
@@ -12,6 +12,12 @@ public class PhaseTimer extends Thread {
 
     @Override
     public void run() {
+
+        Protocol phaseProtocol = new PhaseSubGameProtocol()
+                .setPhaseName(this.phase.getClass().getSimpleName());
+        System.out.println(this.phase.getClass().getSimpleName());
+        this.gameContext.getGameRoom().sendProtocol(phaseProtocol);
+
         while (remainPhaseTime > 0) {
             try {
                 sleep(1000);
@@ -37,20 +43,14 @@ public class PhaseTimer extends Thread {
 
         // 게임이 끝난 경우
         else {
-            Protocol protocol = new EndgameSubSystemProtocol();
-            this.gameContext.getGameRoom().sendProtocol(protocol);
+            Protocol endGameProtocol = new EndgameSubSystemProtocol();
+            this.gameContext.getGameRoom().sendProtocol(endGameProtocol);
             System.out.println("게임 종료");
         }
     }
 
     public void setPhase(Phase phase) {
         this.phase = phase;
-
-        Protocol protocol = new PhaseSubGameProtocol()
-                                .setPhaseName(this.phase.getClass().getSimpleName());
-        System.out.println(this.phase.getClass().getSimpleName());
-        this.gameContext.getGameRoom().sendProtocol(protocol);
-
         this.remainPhaseTime = phase.getInterval();
     }
 


### PR DESCRIPTION
원인
1. State Pattern의 State를 설정하는 PhaseTimer.setPhase() 내부에서, 다음 Phase로 정보를 저장할 때 페이즈가 변경되었다고 프로토콜을 전송
2. Phase.executeResult() 내부에서 결과에 따라 PhaseTimer.setPhase()를 호출하여 다음 Phase 정보를 저장함
3. 현재 Phase에 대한 PhaseTimer 종료 후, 다음 Phase에 대한 PhaseTimer 스레드객체 생성 시 PhaseTimer.setPhase()를 사용하는데, 이때 또 다시 프로토콜을 전송함

수정
1. PhaseTimer.setPhase()는 Phase의 변경 및 Phase에 따른 유지시간 정보만 세팅, 프로토콜 전송은 하지 않음.
2. PhaseTimer.run() 메서드에서 Phase가 시작했다는 프로토콜을 전송하고 카운트를 시작
